### PR TITLE
fix(outputs.go): remove single quotes from k8s outputs

### DIFF
--- a/pkg/helm/outputs.go
+++ b/pkg/helm/outputs.go
@@ -27,7 +27,7 @@ func getSecret(client kubernetes.Interface, namespace, name, key string) ([]byte
 
 func (m *Mixin) getOutput(resourceType, resourceName, namespace, jsonPath string) ([]byte, error) {
 	args := []string{"get", resourceType, resourceName}
-	args = append(args, fmt.Sprintf("-o=jsonpath='%s'", jsonPath))
+	args = append(args, fmt.Sprintf("-o=jsonpath=%s", jsonPath))
 	if namespace != "" {
 		args = append(args, fmt.Sprintf("--namespace=%s", namespace))
 	}


### PR DESCRIPTION
Removes the single quotes around a k8s output (also done in the k8s mixin: https://github.com/getporter/porter/pull/1227/files#diff-ee3f112df3df9e8ec5f3f9f98618987fR97)

I originally had designs for a refactor to enable sharing the same bit of code but wanted to get the fix in while other tasks take priority.

Closes https://github.com/deislabs/porter-helm/issues/71