### PR TITLE
Update helm to fix stable chart move

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Repositories
 - helm:
     repositories:
       stable:
-        url: "https://kubernetes-charts.storage.googleapis.com"
+        url: "https://charts.helm.sh/stable
 ```
 
 ### Mixin Syntax

--- a/examples/mysql/porter.yaml
+++ b/examples/mysql/porter.yaml
@@ -3,7 +3,7 @@ mixins:
     clientVersion: v2.15.2
     repositories:
       stable:
-        url: "https://kubernetes-charts.storage.googleapis.com"
+        url: "https://charts.helm.sh/stable"
 
 name: helm-mysql
 version: 0.1.0

--- a/pkg/helm/build.go
+++ b/pkg/helm/build.go
@@ -45,7 +45,7 @@ type BuildInput struct {
 // - helm:
 //	  repositories:
 //	    stable:
-//		  url: "https://kubernetes-charts.storage.googleapis.com"
+//		  url: "https://charts.helm.sh/stable"
 
 type MixinConfig struct {
 	ClientVersion string `yaml:"clientVersion,omitempty"`

--- a/pkg/helm/build_test.go
+++ b/pkg/helm/build_test.go
@@ -40,7 +40,7 @@ RUN apt-get update && \
 		err = m.Build()
 		require.NoError(t, err, "build failed")
 		wantOutput := fmt.Sprintf(buildOutput, m.HelmClientVersion) +
-			"\nRUN helm repo add stable kubernetes-charts" +
+			"\nRUN helm repo add stable stable-charts" +
 			"\nRUN helm repo update"
 		gotOutput := m.TestContext.GetOutput()
 		assert.Equal(t, wantOutput, gotOutput)
@@ -60,7 +60,7 @@ RUN apt-get update && \
 		assert.Contains(t, gotOutput, fmt.Sprintf(buildOutput, m.HelmClientVersion))
 		assert.Contains(t, gotOutput, "RUN helm repo add harbor https://helm.getharbor.io")
 		assert.Contains(t, gotOutput, "RUN helm repo add jetstack https://charts.jetstack.io")
-		assert.Contains(t, gotOutput, "RUN helm repo add stable kubernetes-charts")
+		assert.Contains(t, gotOutput, "RUN helm repo add stable stable-charts")
 		assert.Contains(t, gotOutput, "RUN helm repo update")
 	})
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -16,7 +16,7 @@ import (
 	k8s "k8s.io/client-go/kubernetes"
 )
 
-const defaultHelmClientVersion string = "v2.15.2"
+const defaultHelmClientVersion string = "v2.17.0"
 
 // Helm is the logic behind the helm mixin
 type Mixin struct {

--- a/pkg/helm/testdata/build-input-with-valid-config-multi-repos.yaml
+++ b/pkg/helm/testdata/build-input-with-valid-config-multi-repos.yaml
@@ -1,7 +1,7 @@
 config:
   repositories:
     stable:
-      url: "kubernetes-charts"
+      url: "stable-charts"
     jetstack:
       url: "https://charts.jetstack.io"
     harbor:

--- a/pkg/helm/testdata/build-input-with-valid-config.yaml
+++ b/pkg/helm/testdata/build-input-with-valid-config.yaml
@@ -1,7 +1,7 @@
 config:
   repositories:
     stable:
-      url: "kubernetes-charts"
+      url: "stable-charts"
 install:
   - helm:
       description: "Install MySQL"


### PR DESCRIPTION
* Reference the new stable chart location
* Use the version of helm 2 that defaults to the new stable chart repository

Fixes #80 

I will immediately cut a new release after this is merged.