### PR TITLE
Publicly rename the mixin to helm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,34 @@
-# Helm Mixin for Porter
+# Helm v2 Mixin for Porter
 
-[![Build Status](https://dev.azure.com/getporter/porter/_apis/build/status/helm-mixin?branchName=main)](https://dev.azure.com/getporter/porter/_build/latest?definitionId=11&branchName=main)
+[![Build Status](https://dev.azure.com/getporter/porter/_apis/build/status/helm2-mixin?branchName=main)](https://dev.azure.com/getporter/porter/_build/latest?definitionId=11&branchName=main)
 
 <img src="https://porter.sh/images/mixins/helm.svg" align="right" width="150px"/>
 
-This is a Helm mixin for [Porter](https://github.com/getporter/porter). It executes the
-appropriate helm command based on which action it is included within: `install`,
-`upgrade`, or `delete`.
+This is a Helm v2 mixin for [Porter](https://github.com/getporter/porter). It
+executes the appropriate helm command based on which action it is included
+within: `install`, `upgrade`, or `delete`.
+
+🚨 [Helm v2 is deprecated](https://helm.sh/blog/helm-2-becomes-unsupported/) so
+you should move to Helm v3 as soon as possible. After you [migrate to Helm
+3](https://helm.sh/docs/topics/v2_v3_migration/), use the [Helm 3
+mixin](https://github.com/MChorfa/porter-helm3). 🚀
 
 ### Install or Upgrade
 
 ```shell
-porter mixin install helm
+porter mixin install helm2
 ```
 
 ### Mixin Configuration
 
-Helm client
+Helm client version
 
 ```yaml
 - helm:
-    clientVersion: v2.15.2
+    clientVersion: v2.17.0
 ```
 
-Repositories
+Add repositories
 
 ```yaml
 - helm:

--- a/cmd/helm/build.go
+++ b/cmd/helm/build.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"get.porter.sh/mixin/helm/pkg/helm"
+	"get.porter.sh/mixin/helm2/pkg/helm"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"get.porter.sh/mixin/helm/pkg/helm"
+	"get.porter.sh/mixin/helm2/pkg/helm"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/helm/invoke.go
+++ b/cmd/helm/invoke.go
@@ -1,9 +1,8 @@
 package main
 
 import (
+	"get.porter.sh/mixin/helm2/pkg/helm"
 	"github.com/spf13/cobra"
-
-	"get.porter.sh/mixin/helm/pkg/helm"
 )
 
 func buildInvokeCommand(mixin *helm.Mixin) *cobra.Command {

--- a/cmd/helm/main.go
+++ b/cmd/helm/main.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"os"
 
-	"get.porter.sh/mixin/helm/pkg/helm"
+	"get.porter.sh/mixin/helm2/pkg/helm"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +20,7 @@ func buildRootCommand(in io.Reader) *cobra.Command {
 	m.In = in
 	cmd := &cobra.Command{
 		Use:  "helm",
-		Long: "A helm mixin for porter 👩🏽‍✈️",
+		Long: "A helm v2 mixin for porter️",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// Enable swapping out stdout/stderr for testing
 			m.Out = cmd.OutOrStdout()

--- a/cmd/helm/schema.go
+++ b/cmd/helm/schema.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"get.porter.sh/mixin/helm/pkg/helm"
+	"get.porter.sh/mixin/helm2/pkg/helm"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/helm/uninstall.go
+++ b/cmd/helm/uninstall.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"get.porter.sh/mixin/helm/pkg/helm"
+	"get.porter.sh/mixin/helm2/pkg/helm"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"get.porter.sh/mixin/helm/pkg/helm"
+	"get.porter.sh/mixin/helm2/pkg/helm"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"get.porter.sh/mixin/helm/pkg/helm"
+	"get.porter.sh/mixin/helm2/pkg/helm"
 	"get.porter.sh/porter/pkg/porter/version"
 	"github.com/spf13/cobra"
 )

--- a/examples/mysql/porter.yaml
+++ b/examples/mysql/porter.yaml
@@ -1,6 +1,6 @@
 mixins:
 - helm:
-    clientVersion: v2.15.2
+    clientVersion: v2.17.0
     repositories:
       stable:
         url: "https://charts.helm.sh/stable"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module get.porter.sh/mixin/helm
+module get.porter.sh/mixin/helm2
 
 go 1.13
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"get.porter.sh/mixin/helm/pkg/kubernetes"
+	"get.porter.sh/mixin/helm2/pkg/kubernetes"
 	"get.porter.sh/porter/pkg/context"
 	"github.com/ghodss/yaml" // We are not using go-yaml because of serialization problems with jsonschema, don't use this library elsewhere
 	"github.com/gobuffalo/packr/v2"

--- a/pkg/helm/helpers.go
+++ b/pkg/helm/helpers.go
@@ -9,7 +9,7 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
-const MockHelmClientVersion string = "v2.15.2"
+const MockHelmClientVersion string = "v2.17.0"
 
 type TestMixin struct {
 	*Mixin

--- a/pkg/helm/version.go
+++ b/pkg/helm/version.go
@@ -1,7 +1,7 @@
 package helm
 
 import (
-	"get.porter.sh/mixin/helm/pkg"
+	"get.porter.sh/mixin/helm2/pkg"
 	"get.porter.sh/porter/pkg/mixin"
 	"get.porter.sh/porter/pkg/pkgmgmt"
 	"get.porter.sh/porter/pkg/porter/version"

--- a/pkg/helm/version_test.go
+++ b/pkg/helm/version_test.go
@@ -4,11 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"get.porter.sh/mixin/helm2/pkg"
 	"get.porter.sh/porter/pkg/porter/version"
 	"get.porter.sh/porter/pkg/printer"
 	"github.com/stretchr/testify/require"
-
-	"get.porter.sh/mixin/helm/pkg"
 )
 
 func TestPrintVersion(t *testing.T) {


### PR DESCRIPTION
* Keep the binary and mixin yaml the same, so people can use `helm: ...` in the porter manifests still
* The mixin source code is moving to get.porter.sh/mixins/helm2 so that it doesn't appear to be THE helm mixin.
* Tell people to use MChorfa's helm3 mixin.

TODO:
- [ ] Rename this repository to getporter/helm2-mixin
